### PR TITLE
Introduce checkpointing and restart support for MPI-parallel inversions with STiC

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,54 @@ Once the inversion is completed, you can visualize the result with the plot.py s
 python plot.py
 ```
 
+
+## Checkpointing and Restarting Inversions
+
+STiC now supports **checkpointing and restart of MPI-parallel inversions**, allowing long runs to be safely resumed after interruption (e.g., wall-time limits or system failures).
+
+Checkpointing periodically stores the current **already computed** atmospheric model and synthetic profiles to disk. Restarting allows the inversion to continue from the last completed pixel instead of starting from scratch.
+
+### Enabling checkpointing
+
+Checkpointing is controlled via a new varible that should be added to your **input.cfg**:
+
+- `is_checkpointing = 0`  
+  Checkpointing is disabled (default behavior).
+
+- `is_checkpointing > 0`  
+  A checkpoint is written every **N pixels** computed.
+
+**ATTENTION:** Writing checkpoints too frequently can introduce significant I/O overhead.  
+For example, for a 400 × 400 pixel grid, writing a single checkpoint can take on the order of **2 seconds**.
+
+It is recommended to configure **is_checkpointing** to **no more frequently than every `N_proc × 10`**, where `N_proc` is the number of MPI processes.
+
+Larger values of **is_checkpointing** (i.e., less frequent checkpoints) are generally preferable to avoid excessive overhead.
+
+The checkpoint is written as partial outputs using the same files indicated in your **input.cfg**:
+
+- `output_profiles =`
+- `output_atmos =` 
+
+
+### Restarting from a checkpoint
+
+Restarting an inversion from previously written checkpoint files is controlled via another variable in your **input.cfg**:
+
+- `is_restarting = 0`  
+  Start a new inversion from scratch (default behavior).  
+  **Files indicated by `output_profiles =` and `output_atmos =` must not already exist**.
+
+- `is_restarting = 1`  
+  Resume an inversion from existing checkpoint files.  
+  **Files indicated by `output_profiles =` and `output_atmos =` must exist and they contain the checkpoint stored previously**.
+
+STiC performs strict consistency checks at startup:
+
+- If `is_restarting != 0` and `output_profiles =` or `output_atmos =` files are missing, the code aborts with a clear error message.
+- If `is_restarting == 0` and `output_profiles =` or `output_atmos =` files already exist, the code aborts to prevent accidental overwriting.
+
+
 ## Acknowledgements
 
 We are gratefull to N. Piskunov for allowing us to use his excellent EOS in our code.

--- a/src/depthmodel.cc
+++ b/src/depthmodel.cc
@@ -1411,7 +1411,7 @@ void mdepthall::write_model2(iput_t const& input, string &filename, int tstep){
 
   
   /* --- Init vars & dims if firsttime --- */
-  if(firsttime){
+  if (firsttime && need_init){
 
     ofile->initDim({"time","y", "x", "ndep"}, dims);
 

--- a/src/depthmodel.cc
+++ b/src/depthmodel.cc
@@ -1380,28 +1380,38 @@ void mdepthall::write_model(string &filename, int tstep){
   ofile.write_Tstep(string("pgas"),    pgas,  tstep);
 }
 
-
-
-void mdepthall::write_model2(iput_t const& input, string &filename, int tstep){
-
-  static bool firsttime = true;
+static io* get_atmos_io(const iput_t& input, std::string &filename, bool &need_init) {
   static io *ofile = nullptr;
-  static bool need_init = false;
+  static std::string opened_file;
 
-  if (ofile == nullptr) {
-    // If restarting and file exists -> open in write mode (do not delete)
-    // Otherwise -> create fresh file (replace)
+  if (ofile == nullptr || opened_file != filename) {
+
+    if (ofile != nullptr) {
+      delete ofile;
+      ofile = nullptr;
+    }
+
     netCDF::NcFile::FileMode mode = netCDF::NcFile::replace;
+    need_init = true;
 
     if (input.is_restarting != 0 && bfile_exists(filename)) {
       mode = netCDF::NcFile::write;
-    } else {
-      mode = netCDF::NcFile::replace;
-      need_init = true;  // new file -> must create dims/vars
+      need_init = false;
     }
 
     ofile = new io(filename, mode);
+    opened_file = filename;
   }
+
+  return ofile;
+}
+
+
+void mdepthall::write_model2(iput_t const& input, string &filename, int tstep){
+  
+  bool need_init = false;
+  io *ofile = get_atmos_io(input, filename, need_init);
+  
 
   
   /* --- Dims --- */
@@ -1411,7 +1421,7 @@ void mdepthall::write_model2(iput_t const& input, string &filename, int tstep){
 
   
   /* --- Init vars & dims if firsttime --- */
-  if (firsttime && need_init){
+  if (need_init){
 
     ofile->initDim({"time","y", "x", "ndep"}, dims);
 
@@ -1438,7 +1448,6 @@ void mdepthall::write_model2(iput_t const& input, string &filename, int tstep){
     
   }
 
-  firsttime = false;
   
   {
   mat<double> tmp((vector<int>){dims[1], dims[2], dims[3]});
@@ -1521,6 +1530,103 @@ void mdepthall::write_model2(iput_t const& input, string &filename, int tstep){
 
   
 }
+
+void mdepthall::write_model2_pixels(iput_t const& input, std::string &filename,
+                                   int tstep, long seq0, long seq1)
+{
+  std::string inam = "mdepthall::write_model2_pixels: ";
+
+  bool need_init = false;
+  io *ofile = get_atmos_io(input, filename, need_init);
+
+
+  /* --- Dims (same as write_model2) --- */
+  std::vector<int> cdims = cub.getdims();
+  std::vector<int> dims = {0, cdims[0], cdims[1], cdims[3]}; // time,y,x,ndep
+
+  const long ny   = (long)dims[1];
+  const long nx   = (long)dims[2];
+  const long ndep = (long)dims[3];
+  const long ntot = ny * nx;
+
+  // Clamp and validate range
+  if (seq1 < seq0) return;
+  if (seq0 < 0) seq0 = 0;
+  if (seq1 >= ntot) seq1 = ntot - 1;
+  if (seq1 < seq0) return;
+
+  /* --- Init vars & dims if firsttime --- */
+  if (need_init) {
+
+    ofile->initDim({"time","y", "x", "ndep"}, dims);
+
+    ofile->initVar<float>(std::string("vlos"),    {"time","y", "x", "ndep"});
+    ofile->initVar<float>(std::string("temp"),    {"time","y", "x", "ndep"});
+    ofile->initVar<float>(std::string("vturb"),   {"time","y", "x", "ndep"});
+    ofile->initVar<float>(std::string("blong"),   {"time","y", "x", "ndep"});
+    ofile->initVar<float>(std::string("bhor"),    {"time","y", "x", "ndep"});
+    ofile->initVar<float>(std::string("azi"),     {"time","y", "x", "ndep"});
+    ofile->initVar<float>(std::string("ltau500"), {"time","y", "x", "ndep"});
+    ofile->initVar<float>(std::string("z"),       {"time","y", "x", "ndep"});
+    ofile->initVar<float>(std::string("pgas"),    {"time","y", "x", "ndep"});
+    ofile->initVar<float>(std::string("rho"),     {"time","y", "x", "ndep"});
+    ofile->initVar<float>(std::string("nne"),     {"time","y", "x", "ndep"});
+    ofile->initVar<float>(std::string("cmass"),   {"time","y", "x", "ndep"});
+
+    ofile->initVar<float>(std::string("transition_region_loc"),   {"time","y", "x"});
+    ofile->initVar<float>(std::string("transition_region_scale"), {"time","y", "x"});
+    ofile->initVar<int>(  std::string("transition_region_nGrid"), {"time","y", "x"});
+  }
+
+
+  // Convert sequential range to y/x bounds
+  const long y0 = seq0 / nx;
+  const long x0 = seq0 % nx;
+  const long y1 = seq1 / nx;
+  const long x1 = seq1 % nx;
+
+  // Helper: fill tmp only for pixels in [seq0..seq1] from cub(:,:,ip,:)
+  auto fill_tmp_ip = [&](mat<double> &tmp, int ip){
+    for(long yy = y0; yy <= y1; ++yy){
+      long seg_x0 = (yy == y0) ? x0 : 0;
+      long seg_x1 = (yy == y1) ? x1 : (nx - 1);
+      for(long xx = seg_x0; xx <= seg_x1; ++xx){
+        memcpy(&tmp((int)yy,(int)xx,0), &cub((int)yy,(int)xx,ip,0), (size_t)ndep * sizeof(double));
+      }
+    }
+  };
+
+  /* --- 4D vars (time,y,x,ndep) via tmp --- */
+  {
+    mat<double> tmp((std::vector<int>){(int)ny, (int)nx, (int)ndep});
+
+    fill_tmp_ip(tmp, 0);  ofile->write_Tstep_pixels<double>(std::string("temp"),    tmp, tstep, seq0, seq1, (int)nx);
+    fill_tmp_ip(tmp, 1);  ofile->write_Tstep_pixels<double>(std::string("vlos"),    tmp, tstep, seq0, seq1, (int)nx);
+    fill_tmp_ip(tmp, 2);  ofile->write_Tstep_pixels<double>(std::string("vturb"),   tmp, tstep, seq0, seq1, (int)nx);
+    fill_tmp_ip(tmp, 3);  ofile->write_Tstep_pixels<double>(std::string("blong"),   tmp, tstep, seq0, seq1, (int)nx);
+    fill_tmp_ip(tmp, 4);  ofile->write_Tstep_pixels<double>(std::string("bhor"),    tmp, tstep, seq0, seq1, (int)nx);
+    fill_tmp_ip(tmp, 5);  ofile->write_Tstep_pixels<double>(std::string("azi"),     tmp, tstep, seq0, seq1, (int)nx);
+
+    fill_tmp_ip(tmp, 9);  ofile->write_Tstep_pixels<double>(std::string("ltau500"), tmp, tstep, seq0, seq1, (int)nx);
+    fill_tmp_ip(tmp,10);  ofile->write_Tstep_pixels<double>(std::string("z"),       tmp, tstep, seq0, seq1, (int)nx);
+
+    fill_tmp_ip(tmp, 6);  ofile->write_Tstep_pixels<double>(std::string("pgas"),    tmp, tstep, seq0, seq1, (int)nx);
+    fill_tmp_ip(tmp, 7);  ofile->write_Tstep_pixels<double>(std::string("rho"),     tmp, tstep, seq0, seq1, (int)nx);
+    fill_tmp_ip(tmp, 8);  ofile->write_Tstep_pixels<double>(std::string("nne"),     tmp, tstep, seq0, seq1, (int)nx);
+
+    fill_tmp_ip(tmp,11);  ofile->write_Tstep_pixels<double>(std::string("cmass"),   tmp, tstep, seq0, seq1, (int)nx);
+  }
+
+  /* --- 3D vars (time,y,x) --- */
+  {
+    ofile->write_Tstep_pixels<double>(std::string("transition_region_loc"),   tr_loc, tstep, seq0, seq1, (int)nx);
+    ofile->write_Tstep_pixels<double>(std::string("transition_region_scale"), tr_amp, tstep, seq0, seq1, (int)nx);
+    ofile->write_Tstep_pixels<int>(   std::string("transition_region_nGrid"), tr_N,   tstep, seq0, seq1, (int)nx);
+  }
+
+  ofile->sync();
+}
+
 
 
 void Ncompress(int const n,  double*  x,  double*  y, int const nn,  double*  xx, double*  yy)

--- a/src/depthmodel.h
+++ b/src/depthmodel.h
@@ -102,6 +102,8 @@ class mdepthall{
   void expand(int n, double *x, double *y, int nn, double *xx, double *yy, int interpolation = 0);
   void write_model(std::string &filename, int tstep = 0);
   void write_model2(iput_t const& input, std::string &filename, int tstep = 0);
+  void write_model2_pixels(iput_t const& input, std::string &filename, int tstep, long seq0, long seq1);
+
 
 };
 typedef mdepthall mdepthall_t;

--- a/src/input.cc
+++ b/src/input.cc
@@ -73,6 +73,9 @@ iput_t read_input(std::string filename, bool verbose){
   iput_t input = {};
   //memset(&input, 0, sizeof(iput_t));
   
+  // Set default checkpoint value, that is, start from the beginning
+  input.restart_from_pixel = 0;
+
   // Default values
   input.mu = 1.0; // default
   input.npack = 1; // default
@@ -118,6 +121,7 @@ iput_t read_input(std::string filename, bool verbose){
   input.inv_depth_opt = 0;
   input.nresp = 0;
   input.fit_tr = 0;
+  
   
   // Open File and read
   std::ifstream in(filename, std::ios::in | std::ios::binary);
@@ -455,6 +459,10 @@ iput_t read_input(std::string filename, bool verbose){
 	  input.nodes.vturb.resize(param.size());
 	  for(int ii = 0; ii<(int)param.size(); ii++) input.nodes.vturb[ii] = std::stod(param[ii]);
 	}
+  else if(key == "restart_from_pixel"){
+    input.restart_from_pixel = atol(field.c_str());
+    set = true;
+  }
 	set = true;
       }
       else if(key == "") set = false;

--- a/src/input.cc
+++ b/src/input.cc
@@ -139,6 +139,10 @@ iput_t read_input(std::string filename, bool verbose){
 	input.imodel = field;
 	set = true;
       }
+      else if(key == "restart_from_pixel"){
+    input.restart_from_pixel = atol(field.c_str());
+    set = true;
+  }
       else if(key == "input_profiles"){
 	input.iprof = field;
 	set = true;	
@@ -459,10 +463,6 @@ iput_t read_input(std::string filename, bool verbose){
 	  input.nodes.vturb.resize(param.size());
 	  for(int ii = 0; ii<(int)param.size(); ii++) input.nodes.vturb[ii] = std::stod(param[ii]);
 	}
-  else if(key == "restart_from_pixel"){
-    input.restart_from_pixel = atol(field.c_str());
-    set = true;
-  }
 	set = true;
       }
       else if(key == "") set = false;

--- a/src/input.cc
+++ b/src/input.cc
@@ -74,8 +74,12 @@ iput_t read_input(std::string filename, bool verbose){
   //memset(&input, 0, sizeof(iput_t));
   
   // Set default checkpoint value, that is, start from the beginning
-  input.restart_from_pixel = 0;
-
+  input.is_restarting = 0;
+  // Checkpointing is off by default
+  input.is_checkpointing = 0; 
+  // Restart pixel calculated based on existing output file
+  input.restart_pixel    = 0;
+  
   // Default values
   input.mu = 1.0; // default
   input.npack = 1; // default
@@ -139,10 +143,14 @@ iput_t read_input(std::string filename, bool verbose){
 	input.imodel = field;
 	set = true;
       }
-      else if(key == "restart_from_pixel"){
-    input.restart_from_pixel = atol(field.c_str());
-    set = true;
+    else if(key == "is_restarting"){
+  input.is_restarting = atoi(field.c_str());
+  set = true;
   }
+    else if(key == "is_checkpointing"){
+  input.is_checkpointing = atoi(field.c_str());
+  set = true;
+    }
       else if(key == "input_profiles"){
 	input.iprof = field;
 	set = true;	

--- a/src/input.h
+++ b/src/input.h
@@ -106,7 +106,10 @@ struct iput{
   std::vector<line_t> lines;
   nodes_t nodes;
 
-  long restart_from_pixel; 
+  int is_checkpointing;
+  int is_restarting;
+  long restart_pixel; 
+
   
 
   iput(){};

--- a/src/input.h
+++ b/src/input.h
@@ -105,6 +105,8 @@ struct iput{
   std::vector<region_t> regions;
   std::vector<line_t> lines;
   nodes_t nodes;
+
+  long restart_from_pixel; 
   
 
   iput(){};

--- a/src/io.cc
+++ b/src/io.cc
@@ -117,3 +117,7 @@ void io::varAttr(std::string vname, std::string attr_n, std::string attr_v)
   if(!exists)
     std::cout<<"io::varAttr: Warning, ["<<vname<<"] does not exist. Cannot set attribute ["<<attr_n<<"]"<<std::endl;
 }
+
+void io::sync() {
+  if (ifile) ifile->sync();
+}

--- a/src/io.h
+++ b/src/io.h
@@ -32,6 +32,7 @@ class io{
     initRead(filename, mode, verbose);
   }
  io():ifile(NULL){};
+ void sync();
  
   // Destructor
   ~io(){

--- a/src/io.h
+++ b/src/io.h
@@ -207,6 +207,150 @@ class io{
     
     return true;
   }
+
+// Storing only a subset of pixels for a given time step to avoid slow checkpoints and avoid rewriting the full grid.
+//
+// The subset is provided as a sequential pixel range [seq0, seq1] (inclusive),
+// where seq = iy * nx + ix (row-major order).
+//
+// Assumptions:
+// - The first two *non-unlimited* dimensions of the netCDF variable are (y, x).
+// - `var` contains the FULL field (y, x, ...), not just the subset.
+// - Supports var.ndims() in [2..4] (e.g., (y,x), (y,x,k), (y,x,k,l)).
+template <class T> bool write_Tstep_pixels(std::string vname, mat<T> &var, int irec,
+                        long seq0, long seq1, int nx){
+
+  std::string inam = "io::write_Tstep_pixels: ";
+
+  if(seq1 < seq0) return true; // nothing to do
+  if(nx <= 0){
+    std::cerr << inam << "ERROR, nx must be > 0" << std::endl;
+    exit(0);
+  }
+
+  // Check if the variable exists
+  netCDF::NcVar ivar;
+  bool exists = false;
+  for(auto &it: vars){
+    if(it.getName().compare(vname) == 0){
+      ivar = it;
+      exists = true;
+      break;
+    }
+  }
+  if(!exists){
+    std::cerr << inam << "ERROR, "<< vname <<" has not been initialized before" << std::endl;
+    exit(0);
+  }
+
+  // Extract dimensions and locate the (first) unlimited dimension (time), if any.
+  std::vector<netCDF::NcDim> idims = ivar.getDims();
+  const int ndim = (int)idims.size();
+
+  std::vector<int> nonunlim;
+  nonunlim.reserve(ndim);
+  for(int d=0; d<ndim; ++d){
+    if(!idims[d].isUnlimited()) nonunlim.push_back(d);
+  }
+
+  if((int)nonunlim.size() < 2){
+    std::cerr << inam << "ERROR, variable ["<<vname<<"] must have at least 2 non-unlimited dimensions" << std::endl;
+    exit(0);
+  }
+
+  // Assume first two non-unlimited dimensions correspond to (y, x)
+  const int ydim = nonunlim[0];
+  const int xdim = nonunlim[1];
+
+  const long ny_file = (long)idims[ydim].getSize();
+  const long nx_file = (long)idims[xdim].getSize();
+  const long ntot = ny_file * nx_file;
+
+  // Clamp requested range to file domain
+  if(seq0 < 0) seq0 = 0;
+  if(seq1 >= ntot) seq1 = ntot - 1;
+  if(seq1 < seq0) return true;
+
+  // Sanity: ensure provided nx matches file nx
+  if(nx_file != (long)nx){
+    std::cerr << inam << "ERROR, nx mismatch: provided nx="<<nx<<" but file nx="<<nx_file<< std::endl;
+    exit(0);
+  }
+
+  // Build baseline start/count (full extents) for all dims
+  std::vector<size_t> start(ndim, 0), count(ndim, 1);
+  for(int d=0; d<ndim; ++d){
+    if(idims[d].isUnlimited()){
+      start[d] = (size_t)irec;
+      count[d] = 1;
+    } else {
+      start[d] = 0;
+      count[d] = idims[d].getSize();
+    }
+  }
+
+  const int var_nd = var.ndims();
+  if(var_nd < 2){
+    std::cerr << inam << "ERROR, input matrix must have at least 2 dimensions" << std::endl;
+    exit(0);
+  }
+  if(var.size(0) != (int)ny_file || var.size(1) != (int)nx_file){
+    std::cerr << inam << "ERROR, input matrix dims (y,x)=("<<var.size(0)<<","<<var.size(1)
+              <<") do not match file dims ("<<ny_file<<","<<nx_file<<")" << std::endl;
+    exit(0);
+  }
+
+  // Convert sequential range to (y,x) bounds
+  long y0 = seq0 / (long)nx;
+  long x0 = seq0 % (long)nx;
+  long y1 = seq1 / (long)nx;
+  long x1 = seq1 % (long)nx;
+
+  // Pack one (y, x-range) slab into a contiguous buffer.
+  auto pack_row_segment = [&](long yy, long xx0, long xcount, std::vector<T> &buf){
+    size_t tail = 1;
+    for(int k=2; k<var_nd; ++k) tail *= (size_t)var.size(k);
+    buf.resize((size_t)xcount * tail);
+
+    size_t p = 0;
+    if(var_nd == 2){
+      for(long xx=xx0; xx<xx0+xcount; ++xx) buf[p++] = var((int)yy,(int)xx);
+    } else if(var_nd == 3){
+      for(long xx=xx0; xx<xx0+xcount; ++xx)
+        for(int a=0; a<var.size(2); ++a)
+          buf[p++] = var((int)yy,(int)xx,a);
+    } else if(var_nd == 4){
+      for(long xx=xx0; xx<xx0+xcount; ++xx)
+        for(int a=0; a<var.size(2); ++a)
+          for(int b=0; b<var.size(3); ++b)
+            buf[p++] = var((int)yy,(int)xx,a,b);
+    } else {
+      std::cerr << inam << "ERROR, write_Tstep_pixels only supports matrices with 2 to 4 dimensions" << std::endl;
+      exit(0);
+    }
+  };
+
+  std::vector<T> buf;
+
+  // Write row-by-row so ranges that cross row boundaries work
+  for(long yy=y0; yy<=y1; ++yy){
+    long seg_x0 = (yy==y0) ? x0 : 0;
+    long seg_x1 = (yy==y1) ? x1 : (long)nx-1;
+    long xcount = seg_x1 - seg_x0 + 1;
+    if(xcount <= 0) continue;
+
+    start[ydim] = (size_t)yy;  count[ydim] = 1;
+    start[xdim] = (size_t)seg_x0; count[xdim] = (size_t)xcount;
+
+    pack_row_segment(yy, seg_x0, xcount, buf);
+    ivar.putVar(start, count, &buf[0]);
+  }
+
+  std::cerr << inam << "writing partial ["<<vname<<"] (t="<< irec
+            <<") seq=["<<seq0<<","<<seq1<<"] to "<<file<<std::endl;
+  return true;
+}
+
   
   template <class T> void initVar(std::string vname, std::vector<std::string> dnames){
     

--- a/src/master_sparse.cc
+++ b/src/master_sparse.cc
@@ -152,12 +152,6 @@ void slaveInversion(iput_t &iput, mdepthall_t &m, mat<double> &obs, mat<double> 
 	fflush(stdout);
       }
 
-              // ---- TEST: stop execution after 10 completed pixels ----
-        if (irec >= 10) {
-          printf("[TEST] Stopping execution at pixel %lu (after checkpoint)\n", irec);
-          fflush(stdout);
-          MPI_Abort(MPI_COMM_WORLD, 0);
-        }
     }
   
     fprintf(stdout, "\n");

--- a/src/master_sparse.cc
+++ b/src/master_sparse.cc
@@ -340,7 +340,7 @@ void do_master_sparse(int myrank, int nprocs,  char hostname[]){
       if (bfile_exists(input.oprof) && bfile_exists(input.oatmos)) {
         have_checkpoint = true;
       } else {
-        std::cerr << "master_sparse: WARNING, is_restarting!=0 but checkpoint files missing:\n"
+        std::cerr << "master_sparse: WARNING, is_restarting != 0 but checkpoint files missing:\n"
               << "  profiles=" << input.oprof << "\n"
               << "  atmos   =" << input.oatmos << "\n"
               << "  -> starting from scratch\n";
@@ -363,8 +363,9 @@ void do_master_sparse(int myrank, int nprocs,  char hostname[]){
   if (have_checkpoint) {
     // Resume: open existing file for writing, DO NOT recreate dims/vars
     if (input.verbose) {
-      std::cerr << "master_sparse: resuming from checkpoint, using existing output file ["
-                << input.oprof << "], is_restarting=" << input.is_restarting << "\n";
+      std::cerr << "master_sparse: checkpoint restart enabled, using existing outputs:\n"
+          << "  profiles=" << input.oprof << "\n"
+          << "  atmos   =" << input.oatmos << "\n";
     }
     opfile.initRead(input.oprof, NcFile::write, input.verbose);
   }
@@ -373,7 +374,6 @@ void do_master_sparse(int myrank, int nprocs,  char hostname[]){
     opfile.initDim({"time","ndep","vtype", "y", "x", "wav", "stokes"},{0, input.ndep, input.nresp, input.ny, input.nx, input.nw_tot, input.ns});
     opfile.initVar<double>(string("profiles"), {"time","y", "x", "wav", "stokes"});
     opfile.initVar<double>(string("wav"), {"wav"});
-
     opfile.write_Tstep<double>(string("wav"), wav);
   }
 
@@ -538,9 +538,7 @@ if(input.mode == 4){
 
       input.restart_pixel = restart_pix;
 
-      fprintf(stdout,
-              "master_sparse: restart enabled -> restart_pixel=%ld (tt=%d)\n",
-              input.restart_pixel, tt);
+      std::cerr << "master_sparse: restart enabled -> restart_pixel=" << input.restart_pixel << " (tt=" << tt << ")\n";
 
       // load atmosphere checkpoint into im
       im.read_model2(input, input.oatmos, tt, true);

--- a/src/master_sparse.cc
+++ b/src/master_sparse.cc
@@ -80,6 +80,19 @@ void slaveInversion(iput_t &iput, mdepthall_t &m, mat<double> &obs, mat<double> 
   MPI_Abort(MPI_COMM_WORLD, EXIT_SUCCESS);
 }
 
+// Seed checkpoint files once per time step so unwritten pixels are not NetCDF _FillValue.
+// IMPORTANT: do not overwrite when restarting from an existing checkpoint (tt==0).
+if (iput.is_checkpointing > 0) {
+  if (!(iput.is_restarting != 0 && tt == 0)) {
+    // Full write ONCE to initialize the file content
+    m.write_model2(iput, iput.oatmos, tt);
+
+    opfile.write_Tstep("profiles", obs, tt);
+    opfile.sync();
+  }
+}
+
+
 
   // Number of pixels we still need to process
   unsigned long remaining = ntot - (unsigned long)iput.restart_pixel;
@@ -118,7 +131,13 @@ void slaveInversion(iput_t &iput, mdepthall_t &m, mat<double> &obs, mat<double> 
             "\nProcessed -> %d%s -> sent=%lu, received=%lu (restart_pixel=%ld, remaining=%lu)\n",
             per, "%", ipix, irec, iput.restart_pixel, remaining);
 
+    
+    // Here we record how many pixels are already stored in the checkpoint.
+    // irec is "pixels completed so far" (next pixel to compute).
+    unsigned long last_chk_irec = 0;
 
+    // On restart we assume pixels [0 .. restart_pixel-1] are already in the checkpoint.
+    if (last_chk_irec == 0) last_chk_irec = (unsigned long)iput.restart_pixel;
 
     /* --- manage packages as long as needed --- */
     while(irec < ntot){
@@ -143,14 +162,26 @@ void slaveInversion(iput_t &iput, mdepthall_t &m, mat<double> &obs, mat<double> 
 
             /* ---- atmos write checkpoint ---- */
             t0 = MPI_Wtime();
-            m.write_model2(iput, iput.oatmos, tt);
+            // m.write_model2(iput, iput.oatmos, tt);
+            // Now we write only the pixels that have been completed since the last checkpoint, to avoid rewriting the full grid at every checkpoint.
+             m.write_model2_pixels(iput, iput.oatmos, tt,
+                            (long)last_chk_irec,
+                            (long)irec - 1);
             t1 = MPI_Wtime();
-            // printf("[timing] atmos write   : %.6f s\n", t1 - t0);
+            printf("[timing] atmos write   : %.6f s\n", t1 - t0);
 
             /* ---- profiles write checkpoint ---- */
             t0 = MPI_Wtime();
-            opfile.write_Tstep("profiles", obs, tt);
+            // opfile.write_Tstep("profiles", obs, tt);
+            // opfile.sync();
+            // Now we write only the pixels that have been completed since the last checkpoint, to avoid rewriting the full grid at every checkpoint.
+            opfile.write_Tstep_pixels("profiles", obs, tt,
+                            (long)last_chk_irec,
+                            (long)irec - 1,
+                            (int)iput.nx);
+
             opfile.sync();
+            last_chk_irec = irec;
             t1 = MPI_Wtime();
             printf("[timing] profiles write: %.6f s\n", t1 - t0);
 

--- a/src/master_sparse.cc
+++ b/src/master_sparse.cc
@@ -56,11 +56,11 @@ void slaveInversion(iput_t &iput, mdepthall_t &m, mat<double> &obs, mat<double> 
 
   /* --- Looking for checkpoints --- */
   if ( (unsigned long)iput.restart_pixel >= ntot) {
-    if (iput.verbose) {
+    // if (iput.verbose) {
       fprintf(stdout,
-              "slaveInversion: restart_pixel=%ld >= ntot=%lu, nothing to do.\n",
+              "Nothing to do. The stored checkpoint already contains the results. slaveInversion: restart_pixel=%ld >= ntot=%lu\n",
               iput.restart_pixel, ntot);
-    }
+    // }
     return;
   }
 
@@ -106,33 +106,58 @@ void slaveInversion(iput_t &iput, mdepthall_t &m, mat<double> &obs, mat<double> 
     /* --- manage packages as long as needed --- */
     while(irec < ntot){
 
-      // Receive processed data from any slave (iproc)
-      fprintf(stdout, "\nAAAAProcessed -> %d -> sent=%lu, received=%lu, ntot=%lu, tocom=%d\n", per, ipix, irec, ntot, tocom);
       comm_master_unpack_data(iproc, iput, obs, x, chi2, irec, dsyn, compute_gradient, m);
-   
 
       double t0, t1;
 
       if (iput.is_checkpointing != 0) {
 
-        /* ---- atmos write checkpoint ---- */
-        t0 = MPI_Wtime();
-        m.write_model2(iput, iput.oatmos, tt);
-        t1 = MPI_Wtime();
-        printf("[timing] atmos write   : %.6f s\n", t1 - t0);
+        // is_checkpointing:
+          //   <= 0 : disabled
+          //   >  0 : checkpoint every N iterations reaching this point
+        static int chk_counter = 0;
+        const int chk_every = (int)iput.is_checkpointing;
 
-        /* ---- profiles write checkpoint ---- */
-        t0 = MPI_Wtime();
-        opfile.write_Tstep("profiles", obs, tt);
-        opfile.sync();
-        t1 = MPI_Wtime();
-        printf("[timing] profiles write: %.6f s\n", t1 - t0);
+        chk_counter++;
 
-        // if (iput.mode == 4) opfile.write_Tstep("derivatives", dsyn, tt);
-        
-        fprintf(stdout, "\nCHECKPOINT DONE !!!!!!!!!!!!!!!!! CHECKPOINT DONE !!!!!!!!!!!!!!!!!\n");
-        fprintf(stdout, "\n[chk] wrote: tt=%d  obs(0,0,0,0)=%.6e  obs(%d,%d,0,0)=%.6e\n", tt, obs(0,0,0,0), (int)(iput.ny-1), (int)(iput.nx-1), obs(iput.ny-1, iput.nx-1, 0, 0));
+        if (chk_counter >= chk_every) {
+
+            chk_counter = 0;  // reset counter
+
+            /* ---- atmos write checkpoint ---- */
+            t0 = MPI_Wtime();
+            m.write_model2(iput, iput.oatmos, tt);
+            t1 = MPI_Wtime();
+            // printf("[timing] atmos write   : %.6f s\n", t1 - t0);
+
+            /* ---- profiles write checkpoint ---- */
+            t0 = MPI_Wtime();
+            opfile.write_Tstep("profiles", obs, tt);
+            opfile.sync();
+            t1 = MPI_Wtime();
+            printf("[timing] profiles write: %.6f s\n", t1 - t0);
+
+            // if (iput.mode == 4) opfile.write_Tstep("derivatives", dsyn, tt);
+
+            long last_seq = (long)irec - 1;
+            long iy = last_seq / (long)iput.nx;
+            long ix = last_seq % (long)iput.nx;
+
+            fprintf(stdout,
+                    "\n------------------------------------------------------------\n"
+                    "[CHECKPOINT] Checkpoint written successfully\n"
+                    "[CHECKPOINT] last_pixel: seq=%ld  (iy=%ld, ix=%ld)\n"
+                    "[CHECKPOINT] progress  : %lu / %lu (%.1f%%)\n"
+                    "------------------------------------------------------------\n",
+                    last_seq,
+                    iy, ix,
+                    irec, ntot, 100.0 * (double)irec / (double)ntot);
+
+            fflush(stdout);
+
+        }
       }
+
 
 
       per = (int)((irec - (unsigned long)iput.restart_pixel) * pno);
@@ -334,21 +359,72 @@ void do_master_sparse(int myrank, int nprocs,  char hostname[]){
   input.ndep = im.ndep;
   
   
-  bool have_checkpoint = false;
   // Cheking if a checkpoint restart is requested and if the partial output file exists.
-  if (input.is_restarting != 0) {
-      if (bfile_exists(input.oprof) && bfile_exists(input.oatmos)) {
-        have_checkpoint = true;
-      } else {
-        std::cerr << "master_sparse: WARNING, is_restarting != 0 but checkpoint files missing:\n"
-              << "  profiles=" << input.oprof << "\n"
-              << "  atmos   =" << input.oatmos << "\n"
-              << "  -> starting from scratch\n";
-        input.is_restarting = 0;
-        have_checkpoint = false;
-        input.restart_pixel = 0;
-      }
+  bool have_checkpoint = false;
+
+// Checking restart/checkpoint consistency
+if (input.is_restarting != 0) {
+
+  if (bfile_exists(input.oprof) && bfile_exists(input.oatmos)) {
+    have_checkpoint = true;
+  } else {
+
+    std::cerr << "\n"
+              << "============================================================\n"
+              << " FATAL ERROR: INVALID CHECKPOINT / RESTART CONFIGURATION\n"
+              << "============================================================\n"
+              << "\n"
+              << "You requested a RESTART (is_restarting != 0), but one or more\n"
+              << "checkpoint files are MISSING.\n"
+              << "\n"
+              << "Expected files:\n"
+              << "  profiles : " << input.oprof << "\n"
+              << "  atmos    : " << input.oatmos << "\n"
+              << "\n"
+              << "How to fix this:\n"
+              << "  - Set is_restarting = 0 to start from scratch\n"
+              << "    OR\n"
+              << "  - Provide BOTH checkpoint files listed above\n"
+              << "\n"
+              << "STiC will now abort execution.\n"
+              << "============================================================\n"
+              << std::endl;
+
+    std::cerr.flush();
+    MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
   }
+
+} else {
+
+  if (bfile_exists(input.oprof) || bfile_exists(input.oatmos)) {
+
+    std::cerr << "\n"
+              << "============================================================\n"
+              << " FATAL ERROR: CHECKPOINT FILES FOUND BUT RESTART DISABLED\n"
+              << "============================================================\n"
+              << "\n"
+              << "You did NOT request a restart (is_restarting == 0), but\n"
+              << "checkpoint files already exist on disk.\n"
+              << "\n"
+              << "Found files:\n"
+              << "  profiles : " << input.oprof << "\n"
+              << "  atmos    : " << input.oatmos << "\n"
+              << "\n"
+              << "How to fix this:\n"
+              << "  - Delete these files to start from scratch\n"
+              << "    OR\n"
+              << "  - Set is_restarting = 1 to resume from checkpoint\n"
+              << "\n"
+              << "STiC will now abort execution.\n"
+              << "============================================================\n"
+              << std::endl;
+
+    std::cerr.flush();
+    MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+  }
+}
+
+
 
   /* ---
      Open output files and init vars to store results 
@@ -509,41 +585,40 @@ if(input.mode == 4){
     // --- If resuming from checkpoint, pre-fill obs with existing synthetic output
     if (inversion && have_checkpoint && input.is_restarting != 0) {
 
-  mat<double> prev_profiles;
-  opfile.read_Tstep<double>("profiles", prev_profiles, tt, input.verbose);
+      mat<double> prev_profiles;
+      opfile.read_Tstep<double>("profiles", prev_profiles, tt, input.verbose);
 
-  long restart_pix = (long)input.ny * (long)input.nx; // default: all done
-  bool found = false;
+      long restart_pix = (long)input.ny * (long)input.nx; // default: all done
+      bool found = false;
 
-  for (int yy = 0; yy < input.ny && !found; ++yy) {
-    for (int xx = 0; xx < input.nx; ++xx) {
+      for (int yy = 0; yy < input.ny && !found; ++yy) {
+        for (int xx = 0; xx < input.nx; ++xx) {
 
-      bool pixel_matches = true;
+          bool pixel_matches = true;
 
-      // check full pixel: all wavelengths, all Stokes
-      for (int iw = 0; iw < input.nw_tot && pixel_matches; ++iw) {
-        for (int is = 0; is < input.ns; ++is) {
-          if (prev_profiles(yy, xx, iw, is) != obs(yy, xx, iw, is)) {
-            pixel_matches = false;
+          for (int iw = 0; iw < input.nw_tot && pixel_matches; ++iw) {
+            for (int is = 0; is < input.ns; ++is) {
+              if (prev_profiles(yy, xx, iw, is) != obs(yy, xx, iw, is)) {
+                pixel_matches = false;
+                break;
+              }
+            }
+          }
+
+          if (pixel_matches) {
+            restart_pix = (long)yy * (long)input.nx + (long)xx;
+            found = true;
             break;
           }
+
+
+          for (int iw = 0; iw < input.nw_tot; ++iw)
+            for (int is = 0; is < input.ns; ++is)
+              obs(yy, xx, iw, is) = prev_profiles(yy, xx, iw, is);
         }
       }
 
-      if (pixel_matches) {
-        restart_pix = (long)yy * (long)input.nx + (long)xx;
-        found = true;
-        break;
-      }
-
-      // pixel computed -> copy synthetic result into obs so later write_Tstep doesn't wipe it
-      for (int iw = 0; iw < input.nw_tot; ++iw)
-        for (int is = 0; is < input.ns; ++is)
-          obs(yy, xx, iw, is) = prev_profiles(yy, xx, iw, is);
-    }
-  }
-
-  input.restart_pixel = restart_pix;
+      input.restart_pixel = restart_pix;
 
           std::cerr << "master_sparse: restart enabled -> restart_pixel=" << input.restart_pixel << " (tt=" << tt << ")\n";
 

--- a/src/master_sparse.cc
+++ b/src/master_sparse.cc
@@ -438,11 +438,11 @@ if (input.is_restarting != 0) {
   io opfile;
   if (have_checkpoint) {
     // Resume: open existing file for writing, DO NOT recreate dims/vars
-    if (input.verbose) {
-      std::cerr << "master_sparse: checkpoint restart enabled, using existing outputs:\n"
-          << "  profiles=" << input.oprof << "\n"
-          << "  atmos   =" << input.oatmos << "\n";
-    }
+    // if (input.verbose) {
+    //   std::cerr << "master_sparse: checkpoint restart enabled, using existing outputs:\n"
+    //       << "  profiles=" << input.oprof << "\n"
+    //       << "  atmos   =" << input.oatmos << "\n";
+    // }
     opfile.initRead(input.oprof, NcFile::write, input.verbose);
   }
   else {
@@ -619,8 +619,38 @@ if(input.mode == 4){
       }
 
       input.restart_pixel = restart_pix;
+      
+      // PRINTING RESTART INFORMATION
+        const long nx = (long)input.nx;
+        const long ny = (long)input.ny;
+        const long ntot = nx * ny;
 
-          std::cerr << "master_sparse: restart enabled -> restart_pixel=" << input.restart_pixel << " (tt=" << tt << ")\n";
+        const long restart_seq = (long)input.restart_pixel; // next pixel to compute (0-based)
+        const long restart_yy  = (nx > 0) ? (restart_seq / nx) : 0;
+        const long restart_xx  = (nx > 0) ? (restart_seq % nx) : 0;
+
+        std::cerr
+          << "\n------------------------------------------------------------\n"
+          << "[RESTART] Checkpoint restart enabled\n"
+          << "------------------------------------------------------------\n"
+          << "[RESTART] profiles file : " << input.oprof  << "\n"
+          << "[RESTART] atmos file    : " << input.oatmos << "\n"
+          << "[RESTART] tt            : " << tt << "\n";
+
+        if (restart_seq >= ntot) {
+          std::cerr
+            << "[RESTART] resume        : nothing left to do (restart_pixel=" << restart_seq
+            << " >= ntot=" << ntot << ")\n";
+        } else {
+          std::cerr
+            << "[RESTART] resume        : restart_pixel=" << restart_seq
+            << "  (yy=" << restart_yy << ", xx=" << restart_xx << ")\n"
+            << "[RESTART] progress      : " << restart_seq << " / " << ntot
+            << " (" << (100.0 * (double)restart_seq / (double)ntot) << "%)\n";
+        }
+
+        std::cerr << "------------------------------------------------------------\n" << std::endl;
+        std::cerr.flush();
 
     im.read_model2(input, input.oatmos, tt, true);
   } else {

--- a/src/master_sparse.cc
+++ b/src/master_sparse.cc
@@ -55,14 +55,31 @@ void slaveInversion(iput_t &iput, mdepthall_t &m, mat<double> &obs, mat<double> 
   unsigned long ntot = (unsigned long)(x.size(0) * x.size(1));
 
   /* --- Looking for checkpoints --- */
-  if ( (unsigned long)iput.restart_pixel >= ntot) {
-    // if (iput.verbose) {
-      fprintf(stdout,
-              "Nothing to do. The stored checkpoint already contains the results. slaveInversion: restart_pixel=%ld >= ntot=%lu\n",
-              iput.restart_pixel, ntot);
-    // }
-    return;
-  }
+  if ((unsigned long)iput.restart_pixel >= ntot) {
+
+  std::cerr << "\n"
+            << "============================================================\n"
+            << " STiC: INVERSION ALREADY COMPLETED (CHECKPOINT RESTART)\n"
+            << "============================================================\n"
+            << "\n"
+            << "The checkpoint indicates that all pixels have already\n"
+            << "been processed.\n"
+            << "\n"
+            << "Restart information:\n"
+            << "  restart_pixel = " << iput.restart_pixel << "\n"
+            << "  total pixels  = " << ntot << "\n"
+            << "\n"
+            << "There is no remaining work to perform. The inversion\n"
+            << "will now terminate normally.\n"
+            << "\n"
+            << "============================================================\n"
+            << std::endl;
+
+  std::cerr.flush();
+
+  MPI_Abort(MPI_COMM_WORLD, EXIT_SUCCESS);
+}
+
 
   // Number of pixels we still need to process
   unsigned long remaining = ntot - (unsigned long)iput.restart_pixel;
@@ -619,7 +636,7 @@ if(input.mode == 4){
       }
 
       input.restart_pixel = restart_pix;
-      
+
       // PRINTING RESTART INFORMATION
         const long nx = (long)input.nx;
         const long ny = (long)input.ny;


### PR DESCRIPTION
## This PR introduces checkpointing and restart support for MPI-parallel inversions with STiC (for now only available for input.mode == 1)

This pull request introduces **checkpointing and restart functionality** to STiC, enabling long-running MPI-parallel inversions to be safely resumed after interruption (e.g., wall-time limits or system failures).

### Summary of changes

- **Checkpointing support**
  - Controlled via the new input parameter `is_checkpointing`
  - Interpreted as a **checkpoint interval** (number of pixels between checkpoints)
  - Checkpoints store:
    - Partial and final atmospheric model output specified by `output_atmos=`
    - Partial and final synthetic profiles output specified by `output_profiles=`
  - Checkpointing is performed exclusively by the master process

- **Restart support**
  - Controlled via `is_restarting`
  - Allows resuming an inversion from previously written checkpoint files
  - The restart position is automatically determined by identifying the last completed pixel from a previous run

- **Improved runtime diagnostics**
  - Clear, structured messages for:
    - Checkpoint creation
    - Restart initialization
    - Resume position and progress
  - Explicit detection and handling of inconsistent checkpoint/restart configurations
  - Clean termination when a checkpoint already contains the full inversion result

- **Documentation updates**
  - README extended with a new section describing:
    - How to enable checkpointing
    - How to restart from a checkpoint
    - Recommended checkpoint frequencies to limit I/O overhead
    - Safety checks and expected behavior

### User-facing behavior

- **Default behavior is slightly changed.** Even though the default is `is_checkpointing = 0` and `is_restarting = 0`, in case `output_atmos=` or `output_profiles=` exist, STiC will terminate to avoid possibly losing already computed values.
- Enabling checkpointing introduces periodic I/O overhead; recommended values for `is_checkpointing` are documented in the updated README.md
- Restarting requires both checkpoint files to be present and consistent (`output_atmos=` and `output_profiles=`)

### Notes

- Checkpointing and restart logic is handled entirely by the master process and is safe for MPI-parallel execution
- The implementation does not modify inversion results and only affects execution control and I/O
